### PR TITLE
Make cURL show return headers in integration tests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Import song
         working-directory: .github
         run: >
-          curl http://127.0.0.1:8000/upload
+          curl -si http://127.0.0.1:8000/upload
           -F files=@brain-implant-cyberpunk-sci-fi-trailer-action-intro-330416.m4a
 
       - name: Wait for song to be imported


### PR DESCRIPTION
This patch makes cURL when called during the integration tests:
- print the returned HTTP headers
- hide the upload progress since it's a bit messy in the logs