### PR TITLE
Use question mark with similar weight to play icon

### DIFF
--- a/templates/player.html
+++ b/templates/player.html
@@ -5,7 +5,7 @@
   ▶
 </div>
 <div id=questionmark class=cover onclick='reveal()'>
-  ?
+  �
 </div>
 <div id=coverart class=cover onclick='next()'>
   <img src={{ cover }} alt='Cover' />


### PR DESCRIPTION
This patch sets the question mark shown when asking users to guess the artist, title and year of release to � since it has a similar weight to the play icon which it replaces. This fits better than just using ?.